### PR TITLE
Use more idiomatic Vue ssr setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 npm-debug.log
 .idea
 /__publish
+App.server.js

--- a/benchmarks/color-picker/vue/components/App.vue
+++ b/benchmarks/color-picker/vue/components/App.vue
@@ -1,0 +1,48 @@
+<template>
+    <div class="colors">
+        <h1>Choose your favorite color:</h1>
+        <div class="colors">
+            <ul v-if="colors.length">
+                <li v-for="(color, i) in colors"
+                    :class="['color', selectedColorIndex === i ? 'selected' : null]"
+                    @click="handleColorClick(i)">
+                    {{ color.name }}
+                </li>
+            </ul>
+            <div v-else>
+                No colors!
+            </div>
+        </div>
+        <div>
+            You chose:
+            <div class="chosen-color">{{ colors[selectedColorIndex].name }}</div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    props: ['colors', 'handleMount', 'handleUpdate'],
+    mounted() {
+        if (this.handleMount) {
+            this.handleMount(this);
+        }
+        window.onMount();
+    },
+    updated() {
+        if (this.handleUpdate) {
+            this.handleUpdate(this);
+        }
+    },
+    data: function() {
+        return {
+            selectedColorIndex: 0
+        }
+    },
+    methods: {
+        handleColorClick: function(colorIndex) {
+            this.selectedColorIndex = colorIndex;
+        }
+    }
+};
+</script>

--- a/benchmarks/color-picker/vue/server.jsx
+++ b/benchmarks/color-picker/vue/server.jsx
@@ -2,7 +2,7 @@ const Vue = require('vue');
 const renderToString = require('vue-server-renderer').createRenderer().renderToString;
 
 
-var App = require('./components/App');
+var App = require('./components/App.server').default;
 
 module.exports = function(colors) {
     return function benchFn(done) {

--- a/benchmarks/color-picker/vue/webpack.config.js
+++ b/benchmarks/color-picker/vue/webpack.config.js
@@ -1,0 +1,24 @@
+const path = require('path')
+const webpack = require('webpack')
+
+module.exports = {
+  entry: path.resolve(__dirname, 'components/App.vue'),
+  target: 'node',
+  output: {
+    filename: 'App.server.js',
+    path: path.resolve(__dirname, 'components'),
+    libraryTarget: 'commonjs2'
+  },
+  module: {
+    rules: [
+      { test: /\.vue$/, use: 'vue-loader' }
+    ]
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"production"'
+      }
+    })
+  ]
+}

--- a/benchmarks/search-results/vue/components/App.vue
+++ b/benchmarks/search-results/vue/components/App.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="search-results">
+    <div>
+        <SearchResultsItem
+          v-for="(item, i) in searchResultsData.items"
+          :key="i"
+          :item="item"
+        />
+    </div>
+    <Footer/>
+  </div>
+</template>
+
+<script>
+import SearchResultsItem from './SearchResultsItem.vue'
+import Footer from './Footer.vue'
+
+export default {
+  props: ['searchResultsData']
+}
+</script>

--- a/benchmarks/search-results/vue/components/Footer.vue
+++ b/benchmarks/search-results/vue/components/Footer.vue
@@ -1,0 +1,478 @@
+<template>
+  <footer id="glbfooter" role="contentinfo" class="gh-w">
+    <div>
+      <div id="rtm_html_1650">
+        <div id="rtm_html_1651">
+        </div>
+        <h2 class="gh-ar-hdn">Additional site navigation</h2>
+        <div id="gf-BIG" class="gffoot">
+          <table class="gf-t">
+            <tbody>
+              <tr>
+                <td>
+                  <ul>
+                    <li class="gf-li">
+                      <h3 class="gf-bttl">
+                        <a href="http://www.ebay.com/sch/allcategories/all-categories" _sp="m571.l3601" class="gf-bttl thrd">Buy</a>
+                      </h3>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/help/account/registration.html" _sp="m571.l2895" class="thrd">Registration</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/ebay-money-back-guarantee/" _sp="m571.l4539" class="thrd">eBay Money Back Guarantee</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/help/buy/basics.html" _sp="m571.l2897" class="thrd">Bidding &amp; buying help</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://stores.ebay.com" _sp="m571.l2899" class="thrd">Stores</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://www.ebay.com/local" _sp="m571.l3221" class="thrd">
+                        eBay Local
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://www.ebay.com/gds" _sp="m571.l5360" class="thrd">eBay guides</a>
+                    </li>
+                  </ul>
+                </td>
+                <td>
+                  <ul>
+                    <li class="gf-li">
+                      <h3 class="gf-bttl">
+                        <a href="http://www.ebay.com/sl/sell" _sp="m571.l2903" class="gf-bttl thrd">
+                          Sell
+                        </a>
+                      </h3>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://www.ebay.com/sl/sell" _sp="m571.l2904" class="thrd">
+                        Start selling
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/sellerinformation/howtosell/sellingbasics.html" _sp="m571.l2905" class="thrd">
+                        Learn to sell
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/sellerinformation/ebayforbusiness/essentials.html" _sp="m571.l2906" class="thrd">
+                        Business sellers
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="https://www.ebaypartnernetwork.com/files/hub/en-US/index.html" _exsp="m571.l2921" class="thrd">
+                        Affiliates
+                      </a>
+                    </li>
+                    <li class="gf-li" style="paddingTop: 8px">
+                      <h3 class="gf-bttl">Tools &amp; apps</h3>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://anywhere.ebay.com/mobile/" _sp="m571.l2944" class="thrd">
+                        Mobile apps
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://anywhere.ebay.com" _exsp="m571.l2923" class="thrd">
+                        Downloads
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://developer.ebay.com" _exsp="m571.l2924" class="thrd">
+                        Developers
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/securitycenter/index.html" _sp="m571.l2907" class="thrd">Security center</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://viv.ebay.com/ws/eBayISAPI.dll?EbayTime" _sp="m571.l2908" class="thrd">eBay official time</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/sitemap.html" _sp="m571.l2909" class="thrd">
+                        Site map
+                      </a>
+                    </li>
+                  </ul>
+                </td>
+                <td>
+                  <ul>
+                    <li class="gf-li">
+                      <h3 class="gf-bttl">eBay companies</h3>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://www.ebayclassifiedsgroup.com/" _exsp="m571.l2927" class="thrd">
+                        eBay Classifieds
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://www.stubhub.com" _exsp="m571.l3208" class="thrd">StubHub</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="https://www.close5.com" _exsp="m571.l3360" class="thrd">Close5</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="https://www.ebayinc.com/our-company/our-other-businesses/" _exsp="m571.l2931" class="thrd">
+                        See all companies
+                      </a>
+                    </li>
+                    <li class="gf-li" style="paddingTop: 8px">
+                      <h3 class="gf-bttl">Stay connected</h3>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://www.ebay.com/stories/" _sp="m571.l2940" class="thrd">
+                        eBay's Blogs
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="https://www.facebook.com/eBay" _exsp="m571.l2942" class="thrd gf-i">
+                        <i class="gspr icfbg">Facebook
+                        </i></a><i class="gspr icfbg">
+                      </i></li><i class="gspr icfbg">
+                      <li class="gf-li">
+                        <a href="http://twitter.com/#!/eBay" _exsp="m571.l2943" class="thrd gf-i">
+                          <i class="gspr ictwg">Twitter
+                          </i></a><i class="gspr ictwg">
+                        </i></li><i class="gspr ictwg">
+                        <li class="gf-li">
+                          <a href="https://plus.google.com/+eBay/posts" _exsp="m571.l3223" class="thrd gf-i">
+                            <i class="gspr icgpg">Google+
+                            </i></a><i class="gspr icgpg">
+                          </i></li><i class="gspr icgpg">
+                        </i></i></i></ul><i class="gspr icfbg"><i class="gspr ictwg"><i class="gspr icgpg">
+                      </i></i></i></td>
+                <td>
+                  <ul>
+                    <li class="gf-li">
+                      <h3 class="gf-bttl">
+                        <a href="http://www.ebayinc.com" _exsp="m571.l2932" class="gf-bttl thrd">
+                          About eBay
+                        </a>
+                      </h3>
+                    </li>
+                    <li class="gf-li">
+                      <a href="https://www.ebayinc.com/our-company/" _exsp="m571.l2933" class="thrd">
+                        Company info
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="https://www.ebayinc.com/stories/news/" _exsp="m571.l2934" class="thrd">News</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="https://investors.ebayinc.com" _exsp="m571.l3269" class="thrd">
+                        Investors
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="https://careers.ebayinc.com/" _exsp="m571.l2937" class="thrd">
+                        Careers
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://www.ebaymainstreet.com" _exsp="m571.l2936" class="thrd">
+                        Government relations
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://cc.ebay.com" _exsp="m571.l2938" class="thrd">
+                        Advertise with us
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/help/policies/overview.html" _sp="m571.l2910" class="thrd">Policies</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/help/policies/programs-vero-ov.html" _sp="m571.l3418" class="thrd">
+                        Verified Rights Owner (VeRO) Program
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://qu.ebay.com/survey?srvName=globalheader+%28footer-US%29" class="thrd gh-survey" title="opens in a new window or tab">
+                        Tell us what you think
+                      </a>
+                    </li>
+                  </ul>
+                </td>
+                <td>
+                  <ul>
+                    <li class="gf-li">
+                      <h3 class="gf-bttl">
+                        <a href="http://ocs.ebay.com/ws/eBayISAPI.dll?CustomerSupport" _sp="m571.l1545" class="gf-bttl thrd">
+                          Help &amp; Contact
+                        </a>
+                      </h3>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://resolutioncenter.ebay.com/" _sp="m571.l1619" class="thrd">
+                        Resolution Center
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/sellerinformation/index.html" _sp="m571.l1613" class="thrd">Seller Information Center</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://ocsnext.ebay.com/ocs/cuhome" _sp="m571.l2911" class="thrd">
+                        Contact us
+                      </a>
+                    </li>
+                    <li class="gf-li" style="paddingTop: 8px">
+                      <h3 class="gf-bttl">
+                        <a href="http://community.ebay.com" _sp="m571.l2912" class="gf-bttl thrd">
+                          Community
+                        </a>
+                      </h3>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://announcements.ebay.com" _sp="m571.l2913" class="thrd">
+                        Announcements
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/community/answercenter/index.html" _sp="m571.l2914" class="thrd">
+                        Answer center
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://forums.ebay.com" _exsp="m571.l2939" class="thrd">
+                        Discussion boards
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://givingworks.ebay.com" _exsp="m571.l3271" class="thrd">
+                        eBay Giving Works
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://givingworks.ebay.com/browse/celebrities" _exsp="m571.l3272" class="thrd">eBay Celebrity</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://groups.ebay.com/groups/EbayGroups/1?redirected=1" _exsp="m571.l2941" class="thrd">Groups</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://www.ebay.com/ets/eBayTopShared" _sp="m571.l2916" class="thrd">
+                        eBay top shared
+                      </a>
+                    </li>
+                    <li class="gf-li" style="paddingTop: 8px">
+                      <h3 class="gf-bttl">eBay Sites</h3>
+                    </li>
+                    <li class="gf-li">
+                      <div class="gf-flags-wpr">
+                        <a aria-expanded="false" aria-controls="gf-f" role="button" class="thrd" title="eBay country sites" _sp="m571.l2586" href="http://www.ebay.com" id="gf-fbtn">
+                          United States<b class="gf-if gspr flus" /> <b id="gf-fbtn-arr" class="gh-sprRetina" />
+                        </a>
+                        <div id="gf-f" style="display: none">
+                          <ul class="gf-ful" role="navigation">
+                            <li class="gf-f-li0">
+                              <a href="http://www.ebay.com.au" class="gf-if-a" title="eBay Australia">
+                                <b class="flau gf-if gspr" />Australia
+                              </a>
+                            </li>
+                            <li class="gf-f-li0">
+                              <a href="http://www.ebay.at" class="gf-if-a" title="eBay Austria">
+                                <b class="flat gf-if gspr" />Austria
+                              </a>
+                            </li>
+                            <li class="gf-f-li0">
+                              <a href="http://www.ebay.be" class="gf-if-a" title="eBay Belgium">
+                                <b class="flbe gf-if gspr" />Belgium
+                              </a>
+                            </li>
+                            <li class="gf-f-li0">
+                              <a href="http://www.ebay.ca" class="gf-if-a" title="eBay Canada">
+                                <b class="flca gf-if gspr" />Canada
+                              </a>
+                            </li>
+                            <li class="gf-f-li0">
+                              <a href="http://www.ebay.cn" class="gf-if-a" title="eBay China">
+                                <b class="flcn gf-if gspr" />China
+                              </a>
+                            </li>
+                            <li class="gf-f-li0">
+                              <a href="http://www.ebay.fr" class="gf-if-a" title="eBay France">
+                                <b class="flfr gf-if gspr" />France
+                              </a>
+                            </li>
+                            <li class="gf-f-li0">
+                              <a href="http://www.ebay.de" class="gf-if-a" title="eBay Germany">
+                                <b class="flde gf-if gspr" />Germany
+                              </a>
+                            </li>
+                            <li class="gf-f-li1 gf-f-li-top">
+                              <a href="http://www.ebay.com.hk" class="gf-if-a" title="eBay Hong Kong">
+                                <b class="flhk gf-if gspr" />Hong Kong
+                              </a>
+                            </li>
+                            <li class="gf-f-li1">
+                              <a href="http://www.ebay.in" class="gf-if-a" title="eBay India">
+                                <b class="flin gf-if gspr" />India
+                              </a>
+                            </li>
+                            <li class="gf-f-li1">
+                              <a href="http://www.ebay.ie" class="gf-if-a" title="eBay Ireland">
+                                <b class="flie gf-if gspr" />Ireland
+                              </a>
+                            </li>
+                            <li class="gf-f-li1">
+                              <a href="http://www.ebay.it" class="gf-if-a" title="eBay Italy">
+                                <b class="flit gf-if gspr" />Italy
+                              </a>
+                            </li>
+                            <li class="gf-f-li1">
+                              <a href="http://www.ebay.co.jp" class="gf-if-a" title="eBay Japan">
+                                <b class="fljp gf-if gspr" />Japan
+                              </a>
+                            </li>
+                            <li class="gf-f-li1">
+                              <a href="http://global.gmarket.co.kr/Home/Main" class="gf-if-a" title="eBay Korea">
+                                <b class="flkr gf-if gspr" />Korea
+                              </a>
+                            </li>
+                            <li class="gf-f-li1">
+                              <a href="http://www.ebay.com.my" class="gf-if-a" title="eBay Malaysia">
+                                <b class="flmy gf-if gspr" />Malaysia
+                              </a>
+                            </li>
+                            <li class="gf-f-li2 gf-f-li-top">
+                              <a href="http://www.ebay.nl" class="gf-if-a" title="eBay Netherlands">
+                                <b class="flnl gf-if gspr" />Netherlands
+                              </a>
+                            </li>
+                            <li class="gf-f-li2">
+                              <a href="http://www.ebay.ph" class="gf-if-a" title="eBay Philippines">
+                                <b class="flph gf-if gspr" />Philippines
+                              </a>
+                            </li>
+                            <li class="gf-f-li2">
+                              <a href="http://www.ebay.pl" class="gf-if-a" title="eBay Poland">
+                                <b class="flpl gf-if gspr" />Poland
+                              </a>
+                            </li>
+                            <li class="gf-f-li2">
+                              <a href="http://www.ebay.com.sg" class="gf-if-a" title="eBay Singapore">
+                                <b class="flsg gf-if gspr" />Singapore
+                              </a>
+                            </li>
+                            <li class="gf-f-li2">
+                              <a href="http://www.ebay.es" class="gf-if-a" title="eBay Spain">
+                                <b class="fles gf-if gspr" />Spain
+                              </a>
+                            </li>
+                            <li class="gf-f-li2">
+                              <a href="http://www.ebay.se" class="gf-if-a" title="eBay Sweden">
+                                <b class="flse gf-if gspr" />Sweden
+                              </a>
+                            </li>
+                            <li class="gf-f-li2">
+                              <a href="http://www.ebay.ch" class="gf-if-a" title="eBay Switzerland">
+                                <b class="flch gf-if gspr" />Switzerland
+                              </a>
+                            </li>
+                            <li class="gf-f-li3 gf-f-li-top">
+                              <a href="http://www.ebay.com.tw" class="gf-if-a" title="eBay Taiwan">
+                                <b class="fltw gf-if gspr" />Taiwan
+                              </a>
+                            </li>
+                            <li class="gf-f-li3">
+                              <a href="http://www.ebay.co.th" class="gf-if-a" title="eBay Thailand">
+                                <b class="flth gf-if gspr" />Thailand
+                              </a>
+                            </li>
+                            <li class="gf-f-li3">
+                              <a href="http://www.gittigidiyor.com" class="gf-if-a" title="eBay Turkey">
+                                <b class="fltr gf-if gspr" />Turkey
+                              </a>
+                            </li>
+                            <li class="gf-f-li3">
+                              <a href="http://www.ebay.co.uk" class="gf-if-a" title="eBay United Kingdom">
+                                <b class="flgb gf-if gspr" />United Kingdom
+                              </a>
+                            </li>
+                            <li class="gf-f-li3">
+                              <a href="http://www.ebay.vn" class="gf-if-a" title="eBay Vietnam">
+                                <b class="flvn gf-if gspr" />Vietnam
+                              </a>
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div id="gf-t-box">
+          <table class="gf-t">
+            <tbody>
+              <tr>
+                <td colSpan={2}>
+                  <ul id="gf-l" class="gf-lb">
+                    <li class="gf-li">
+                      <a href="http://www.ebayinc.com" _exsp="m571.l2602" class="thrd gf-bar-a">
+                        About eBay
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://announcements.ebay.com" _exsp="m571.l2935" class="thrd gf-bar-a">Announcements</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://community.ebay.com" _exsp="m571.l1540" class="thrd gf-bar-a">
+                        Community
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/securitycenter/index.html" _exsp="m571.l2616" class="thrd gf-bar-a">Security Center</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://resolutioncenter.ebay.com/" _sp="m571.l1619" class="thrd gf-bar-a">Resolution Center</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/sellerinformation/index.html" _exsp="m571.l1613" class="thrd gf-bar-a">
+                        Seller Information Center
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/help/policies/overview.html" _exsp="m571.l2604" class="thrd gf-bar-a">Policies</a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="https://www.ebaypartnernetwork.com/files/hub/en-US/index.html" _exsp="m571.l3947" class="thrd gf-bar-a">
+                        Affiliates
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://ocs.ebay.com/ws/eBayISAPI.dll?CustomerSupport" _sp="m571.l1545" class="thrd gf-bar-a">
+                        Help &amp; Contact
+                      </a>
+                    </li>
+                    <li class="gf-li">
+                      <a href="http://pages.ebay.com/sitemap.html" _exsp="m571.l2909" class="thrd gf-bar-a">Site Map</a>
+                    </li>
+                  </ul>
+                </td>
+              </tr>
+              <tr valign="top">
+                <td class="gf-legal">
+                  Copyright © 1995-2016 eBay Inc. All Rights Reserved.
+                  <a href="http://pages.ebay.com/help/policies/user-agreement.html">
+                    User Agreement
+                  </a>,
+                  <a href="http://pages.ebay.com/help/policies/privacy-policy.html">Privacy</a>,
+                  <a href="http://pages.ebay.com/help/account/cookies-web-beacons.html">
+                    Cookies
+                  </a>
+                  and
+                  <a href="http://cgi6.ebay.com/ws/eBayISAPI.dll?AdChoiceLandingPage&partner=0" id="gf-AdChoice">AdChoice</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </footer>
+</template>

--- a/benchmarks/search-results/vue/components/SearchResultsItem.vue
+++ b/benchmarks/search-results/vue/components/SearchResultsItem.vue
@@ -1,0 +1,36 @@
+<template>
+    <div class="search-results-item"
+         :style="{ backgroundColor: purchased ? '#f1c40f' : ''}">
+        <h2>{{ item.title }}</h2>
+
+        <div class="lvpic pic img left">
+        <div class="lvpicinner full-width picW">
+            <a :href="'/buy/' + item.id" class="img imgWr2">
+               <img :src="item.image" alt="item.title">
+            </a>
+        </div>
+        </div>
+
+        <span class="price">{{ item.price }}</span>
+
+        <div v-if="purchased" class="purchased">Purchased!</div>
+        <button v-else class="buy-now" type="button" @click="handleBuyButtonClick">
+            Buy now!
+        </button>
+
+    </div>
+</template>
+
+<script>
+export default {
+    props: ['item'],
+    data () {
+      return { purchased: false }
+    },
+    methods: {
+        handleBuyButtonClick: function(instance) {
+            this.purchased = true;
+        }
+    }
+}
+</script>

--- a/benchmarks/search-results/vue/server.jsx
+++ b/benchmarks/search-results/vue/server.jsx
@@ -2,7 +2,7 @@ const Vue = require('vue');
 const renderToString = require('vue-server-renderer').createRenderer().renderToString;
 
 
-var App = require('./components/App');
+var App = require('./components/App.server').default;
 
 module.exports = function(getNextSearchResults) {
     return function benchFn(done) {

--- a/benchmarks/search-results/vue/webpack.config.js
+++ b/benchmarks/search-results/vue/webpack.config.js
@@ -1,0 +1,24 @@
+const path = require('path')
+const webpack = require('webpack')
+
+module.exports = {
+  entry: path.resolve(__dirname, 'components/App.vue'),
+  target: 'node',
+  output: {
+    filename: 'App.server.js',
+    path: path.resolve(__dirname, 'components'),
+    libraryTarget: 'commonjs2'
+  },
+  module: {
+    rules: [
+      { test: /\.vue$/, use: 'vue-loader' }
+    ]
+  },
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"production"'
+      }
+    })
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run benchmark",
     "start": "node server.js",
-    "benchmark": "node --expose-gc benchmark-server/run.js",
+    "benchmark": "npm run bundle-vue-server && node --expose-gc benchmark-server/run.js",
     "build": "npm run bundle --silent && npm run minify --silent",
     "bundle": "node ./scripts/bundle.js",
     "static": "node ./scripts/static.js",
@@ -19,7 +19,8 @@
     "bundle-marko": "node ./scripts/bundle.js marko",
     "bundle-react": "node ./scripts/bundle.js react",
     "bundle-preact": "node ./scripts/bundle.js preact",
-    "bundle-vue": "node ./scripts/bundle.js vue"
+    "bundle-vue": "node ./scripts/bundle.js vue",
+    "bundle-vue-server": "webpack --config benchmarks/color-picker/vue/webpack.config.js && webpack --config benchmarks/search-results/vue/webpack.config.js"
   },
   "author": "Patrick Steele-Idem <pnidem@gmail.com",
   "license": "MIT",
@@ -71,8 +72,10 @@
     "safe-access": "^0.1.0",
     "serve-static": "^1.8.1",
     "uglify": "^0.1.5",
-    "vue": "^2.4.2",
-    "vue-server-renderer": "^2.2.6",
-    "vueify": "^9.4.1"
+    "vue": "^2.4.4",
+    "vue-loader": "^13.0.4",
+    "vue-server-renderer": "^2.4.4",
+    "vue-template-compiler": "^2.4.4",
+    "webpack": "^3.6.0"
   }
 }


### PR DESCRIPTION
The Vue benchmark implementation is somewhat misrepresenting Vue's full SSR performance because the setup uses JSX and doesn't leverage the template-based compilation improvements in Vue 2.4.

This PR uses the more idiomatic `*.vue` files for Vue components and pre-compiles the components with webpack + vue-loader (this setup has SSR optimization enabled by default).

Updated results on my machine (2017 mbp 13', Node 8.4.0):

```
Warming up...

Warmup complete.

Running "search-results"...

Running benchmark "marko"...

marko x 4,458 ops/sec ±3.64% (78 runs sampled)

Running benchmark "preact"...

preact x 812 ops/sec ±1.68% (81 runs sampled)

Running benchmark "react"...

react x 35.89 ops/sec ±7.81% (48 runs sampled)

Running benchmark "vue"...

vue x 1,494 ops/sec ±4.70% (75 runs sampled)

Running benchmark "inferno"...

inferno x 548 ops/sec ±1.25% (82 runs sampled)

Fastest is marko

--------------


Warming up...

Warmup complete.

Running "color-picker"...

Running benchmark "marko"...

marko x 10,091 ops/sec ±2.15% (85 runs sampled)

Running benchmark "preact"...

preact x 4,995 ops/sec ±0.99% (88 runs sampled)

Running benchmark "react"...

react x 225 ops/sec ±3.61% (74 runs sampled)

Running benchmark "vue"...

vue x 3,292 ops/sec ±2.18% (78 runs sampled)

Running benchmark "inferno"...

inferno x 2,687 ops/sec ±1.15% (86 runs sampled)

Fastest is marko

--------------


DONE!
```